### PR TITLE
Use Yajl to serialize messages to JSON

### DIFF
--- a/lib/fluent/plugin/out_flume.rb
+++ b/lib/fluent/plugin/out_flume.rb
@@ -80,7 +80,7 @@ class FlumeOutput < BufferedOutput
     log.debug "thrift client opened: #{client}"
     begin
       chunk.msgpack_each { |tag, time, record|
-        entry = ThriftFlumeEvent.new(:body      => record.to_json.to_s.force_encoding('UTF-8'),
+        entry = ThriftFlumeEvent.new(:body      => Yajl::Encoder.encode(record),
                                      :headers   => {
                                        'timestamp' => time.to_s,
                                        'tag'       => tag,


### PR DESCRIPTION
Came across a situation similar to one reported in [fluent-plugin-elasticsearch](https://github.com/uken/fluent-plugin-elasticsearch/issues/19) where to_json was causing exceptions.

Will be able to provide extra information later on (and submitted the PR since we don't have access to the flume destination and thus have to use this no longer supported plugin).