### PR TITLE
enable formatter functionality for out_flume (v12)

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -83,7 +83,7 @@ Use flume-ng-fluentd-sink[https://github.com/cosmo0920/flume-ng-fluentd-sink] to
 
 == Flume Output
 
-Please add the following configurations to fluent.conf.  This allows fluentd to output its logs into another Flume server.  Note that fluentd conveys semi-structured data while Flume conveys unstructured data.  Thus the plugin translates semi-structured data into JSON data and conveys it to Flume.
+Please add the following configurations to fluent.conf.  This allows fluentd to output its logs into another Flume server.  Note that fluentd conveys semi-structured data while Flume conveys unstructured data.  Thus the plugin translates semi-structured data into JSON data by default and conveys it to Flume.  The format can be adjusted via formatters.
 
   # Flume output
   <match *>
@@ -98,6 +98,7 @@ These options are supported.
 * port: port number (default: 35863)
 * timeout: thrift protocol timeout (default: 30)
 * remove_prefix: prefix string, removed from the tag (default: nil)
+* format: The format of the thrift body (default: json)
 
 == Contributors
 

--- a/lib/fluent/plugin/out_flume.rb
+++ b/lib/fluent/plugin/out_flume.rb
@@ -85,7 +85,7 @@ class FlumeOutput < BufferedOutput
     log.debug "thrift client opened: #{client}"
     begin
       chunk.msgpack_each { |tag, time, record|
-        entry = ThriftFlumeEvent.new(:body      => record.to_s.force_encoding('UTF-8'),
+        entry = ThriftFlumeEvent.new(:body      => record.force_encoding('UTF-8'),
                                      :headers   => {
                                        'timestamp' => time.to_s,
                                        'tag'       => tag,

--- a/lib/fluent/plugin/out_flume.rb
+++ b/lib/fluent/plugin/out_flume.rb
@@ -25,6 +25,8 @@ class FlumeOutput < BufferedOutput
   config_param :timeout,   :integer, :default => 30
   config_param :remove_prefix,    :string, :default => nil
   config_param :default_category, :string, :default => 'unknown'
+  desc "The format of the thrift body. (default: json)"
+  config_param :format, :string, default: 'json'
 
   unless method_defined?(:log)
     define_method(:log) { $log }
@@ -42,7 +44,11 @@ class FlumeOutput < BufferedOutput
   def configure(conf)
     # override default buffer_chunk_limit
     conf['buffer_chunk_limit'] ||= '1m'
+
     super
+
+    @formatter = Plugin.new_formatter(@format)
+    @formatter.configure(conf)
   end
 
   def start
@@ -62,10 +68,9 @@ class FlumeOutput < BufferedOutput
     if @remove_prefix and
         ( (tag[0, @removed_length] == @removed_prefix_string and tag.length > @removed_length) or
           tag == @remove_prefix)
-      [(tag[@removed_length..-1] || @default_category), time, record].to_msgpack
-    else
-      [tag, time, record].to_msgpack
+      tag = (tag[@removed_length..-1] || @default_category)
     end
+    [tag, time, @formatter.format(tag, time, record)].to_msgpack
   end
 
   def write(chunk)
@@ -80,7 +85,7 @@ class FlumeOutput < BufferedOutput
     log.debug "thrift client opened: #{client}"
     begin
       chunk.msgpack_each { |tag, time, record|
-        entry = ThriftFlumeEvent.new(:body      => record.to_json.to_s.force_encoding('UTF-8'),
+        entry = ThriftFlumeEvent.new(:body      => record.to_s.force_encoding('UTF-8'),
                                      :headers   => {
                                        'timestamp' => time.to_s,
                                        'tag'       => tag,


### PR DESCRIPTION
In order to not be bound to json output only, we added formatter to the flume output plugin.

This patch is for v12 of the API. 